### PR TITLE
[HOPSWORKS-1153] Bump maggy and sparkmagic version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -122,7 +122,7 @@ default['bazel']['url']                = "#{node['download_url']}/bazel-#{node['
 default['openmpi']['version']          = "openmpi-3.1.0.tar.gz"
 
 
-default['jupyter']['sparkmagic']['version']            = "0.12.6"
+default['jupyter']['sparkmagic']['version']            = "0.12.7"
 default['jupyter']['sparkmagic']['url']                = node['download_url'] + "/sparkmagic-" + node['jupyter']['sparkmagic']['version'] + ".tar.gz"
 
 # Pinned Python libary versions to install in the base environments
@@ -140,4 +140,4 @@ default['featurestore']['hops_featurestore_demo_url'] = "#{node['download_url']}
 
 # Maggy - dist optimization for TensorFlow/Spark
 #
-default['maggy']['version']                           = "0.1.1"
+default['maggy']['version']                           = "0.2.2"


### PR DESCRIPTION
Bumping maggy and sparkmagic version to 0.2.2 and 0.12.7
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1153