### PR TITLE
[HOPSWORKS-1366] Upgrade default maggy version to 0.3.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -140,4 +140,4 @@ default['featurestore']['hops_featurestore_demo_url'] = "#{node['download_url']}
 
 # Maggy - dist optimization for TensorFlow/Spark
 #
-default['maggy']['version']                           = "0.2.2"
+default['maggy']['version']                           = "0.3.0"


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1366