### PR TITLE
[HOPSWORKS-1491] Bump maggy version to 0.4.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -141,4 +141,4 @@ default['featurestore']['hops_featurestore_demo_url'] = "#{node['download_url']}
 
 # Maggy - dist optimization for TensorFlow/Spark
 #
-default['maggy']['version']                           = "0.3.0"
+default['maggy']['version']                           = "0.4.*"


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1491

Bumps maggy version to `0.4.*`, this allows us to release bugfixes without having to change the recipe every time.