### PR TITLE
[HOPSWORKS-2647] Support Ubuntu 20.04

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -13,7 +13,7 @@ end
 case node['platform_family']
 when "debian"
 
-  package ["pkg-config", "zip", "g++", "zlib1g-dev", "unzip", "swig", "git", "build-essential", "cmake", "unzip", "libopenblas-dev", "liblapack-dev", "linux-image-#{node['kernel']['release']}", "linux-headers-#{node['kernel']['release']}", "python3", "python3-numpy", "python3-dev", "python3-pip", "python3-lxml", "python3-pillow", "libcupti-dev", "libcurl3-dev", "python3-wheel", "python3-six", "pciutils"]
+  package ["pkg-config", "zip", "g++", "zlib1g-dev", "unzip", "swig", "git", "build-essential", "cmake", "libopenblas-dev", "liblapack-dev", "linux-image-#{node['kernel']['release']}", "linux-headers-#{node['kernel']['release']}", "libcupti-dev", "libcurl3-dev", "pciutils"]
 
 when "rhel"
   if node['rhel']['epel'].downcase == "true"
@@ -39,7 +39,7 @@ when "rhel"
     not_if  "ls -l /usr/src/kernels/$(uname -r)"
   end
 
-  package ['pciutils', 'python3-pip', 'mlocate', 'gcc', 'gcc-c++', 'openssl', 'openssl-devel', 'python3', 'python3-devel', 'python3-lxml', 'python3-pillow', 'libcurl-devel', 'python3-wheel', 'python36-six']
+  package ['pciutils', 'mlocate', 'gcc', 'gcc-c++', 'openssl', 'openssl-devel', 'libcurl-devel']
 end
 
 include_recipe "java"


### PR DESCRIPTION
Remove Python3 library installation directly on the host as they are not needed. Everything that needs Python should use the hops-system Conda environment 